### PR TITLE
Fix: Allow to source setup.bash from any directory

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env
 
-HOST_HOME=`pwd`
+HOST_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 
 V="-v /tmp/env:/env -v $HOST_HOME/catkin_ws/src/pioneer_outdoor:/home/root/catkin_ws/src/pioneer_outdoor:ro -v $HOST_HOME/settings/$HOSTNAME.env:/env/settings.env"


### PR DESCRIPTION
Determine scripts own location and use it for HOST_HOME variable. See http://stackoverflow.com/a/246128

The solution won't work if the script is symlinked.
